### PR TITLE
Fixed a little warning, because using recent ffmpeg

### DIFF
--- a/FFmpegPlayer.cpp
+++ b/FFmpegPlayer.cpp
@@ -581,7 +581,7 @@ int read_thread(void * arg) {
     // Tested on Linux + wine64 : .exe work well using const char * (needs some cast tricks though)
     // does NOT work (as usual) on Windows
     // C:\one_path\filename.ext  becomes  C:~   followed by garbage
-    if(avformat_open_input(&pFormatCtx, is->filename, NULL, NULL) < 0) {
+    if(avformat_open_input(&pFormatCtx, av_strdup(is->filename), NULL, NULL) < 0) {
         ret = -1;
         goto fail;
     }

--- a/FFmpegPlayer.cpp
+++ b/FFmpegPlayer.cpp
@@ -576,6 +576,11 @@ int read_thread(void * arg) {
     }
 
     //open file
+    // TODO : seems to be broken on Windows, because using std::wstring.
+    // works perfectly on Linux : rtsp, filenames, and so on
+    // Tested on Linux + wine64 : .exe work well using const char * (needs some cast tricks though)
+    // does NOT work (as usual) on Windows
+    // C:\one_path\filename.ext  becomes  C:~   followed by garbage
     if(avformat_open_input(&pFormatCtx, is->filename, NULL, NULL) < 0) {
         ret = -1;
         goto fail;

--- a/FFmpegPlayer.cpp
+++ b/FFmpegPlayer.cpp
@@ -994,9 +994,9 @@ void event_loop(VideoState *is) {
 
 int main(int argc, char** argv) {
     VideoState *is = NULL;
-
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(58, 9, 100)
     av_register_all();
-
+#endif
     //using SDL
     if(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_TIMER) != 0) {
         cout<<"could not initialize SDL - "<< SDL_GetError()<<endl;

--- a/FFmpegPlayer.cpp
+++ b/FFmpegPlayer.cpp
@@ -581,7 +581,7 @@ int read_thread(void * arg) {
     // Tested on Linux + wine64 : .exe work well using const char * (needs some cast tricks though)
     // does NOT work (as usual) on Windows
     // C:\one_path\filename.ext  becomes  C:~   followed by garbage
-    if(avformat_open_input(&pFormatCtx, av_strdup(is->filename), NULL, NULL) < 0) {
+    if(avformat_open_input(&pFormatCtx, is->filename, NULL, NULL) < 0) {
         ret = -1;
         goto fail;
     }


### PR DESCRIPTION
Is ffmpeg stable ?  :-)

av_register_all() is now deprecated, and I have added a little change to avoid a warning at buildtime.

Use whatever license you want for the change, if you accept the PR.

Thanks !

